### PR TITLE
Make the "public flags" field optional

### DIFF
--- a/flask_discord_interactions/models/user.py
+++ b/flask_discord_interactions/models/user.py
@@ -31,7 +31,7 @@ class User(LoadableDataclass):
     id: str
     username: str
     discriminator: str
-    public_flags: int
+    public_flags: int = None
     avatar_hash: Optional[str] = None
     bot: Optional[bool] = None
     system: Optional[bool] = None

--- a/flask_discord_interactions/models/user.py
+++ b/flask_discord_interactions/models/user.py
@@ -31,7 +31,7 @@ class User(LoadableDataclass):
     id: str
     username: str
     discriminator: str
-    public_flags: int = None
+    public_flags: Optional[int] = None
     avatar_hash: Optional[str] = None
     bot: Optional[bool] = None
     system: Optional[bool] = None


### PR DESCRIPTION
**Checklist**
This pull request...

- [X] Fixes a bug
- [ ] Adds new functionality
- [ ] Updates documentation and/or examples
- [ ] Adds tests
- [ ] Is a **breaking** change -- existing code written for this library may need to be rewritten to work after these changes.

**Description**
This pull request makes the `public_flags` field in the `User` model optional, reverting part of #118. Discord doesn't always return this field in response to buttons, select menus, etc.

Closes #119.